### PR TITLE
Fix role check in configuration example

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -46,14 +46,11 @@ import (
 //  			if err != nil {
 //  				return nil, err
 //  			}
-//  			return c, nil
-//  		},
-//  		TestOnBorrow: func(c redis.Conn, t time.Time) error {
 //  			if !sentinel.TestRole(c, "master") {
-//  				return errors.New("Role check failed")
-//  			} else {
-//  				return nil
+//  				c.Close()
+//  				return nil, fmt.Errorf("%s is not redis master", masterAddr)
 //  			}
+//  			return c, nil
 //  		},
 //  	}
 //  }


### PR DESCRIPTION
The documentation suggested that when using Redis Sentinel, we should call sentinel.TestRole() every time we retrieve a Redis connection from the connection pool. This runs against the Redis documentation, which says that Sentinel clients should check the server role just once after they established a connection.
https://redis.io/docs/reference/sentinel-clients/

If users of sentinel-go follow the old configuration example they will make many unnecessary ROLE calls to Redis.

This commit fixes the documentation to suggest that users call sentinel.TestRole() from within the Dial callback. This matches what the Redis documentation suggests we do.