### PR TITLE
Improve TestRole error handling

### DIFF
--- a/sentinel.go
+++ b/sentinel.go
@@ -285,9 +285,12 @@ func (s *Sentinel) Close() error {
 // the function returns false. Works with Redis >= 2.8.12.
 // It's not goroutine safe, but if you call this method on pooled connections
 // then you are OK.
-func TestRole(c redis.Conn, expectedRole string) bool {
+func TestRole(c redis.Conn, expectedRole string) (bool, error) {
 	role, err := getRole(c)
-	return err == nil && role == expectedRole
+	if err != nil {
+		return false, err
+	}
+	return role == expectedRole, err
 }
 
 // getRole is a convenience function supplied to query an instance (master or


### PR DESCRIPTION
Previously `TestRole` would return `false` if the `ROLE` command could not be issued for some reason, but this could hide some underlying error, such as a `NOAUTH` message. Return the error message if this happens.